### PR TITLE
ParseNumber regexp accepts negative values

### DIFF
--- a/src/test.js
+++ b/src/test.js
@@ -118,15 +118,20 @@ describe('Lang', function () {
     it('parseNumber', function () {
         expect(_.parseNumber('123')).toEqual(123);
         expect(_.parseNumber(123)).toEqual(123);
+        expect(_.parseNumber('-12')).toEqual(-12);
+        expect(_.parseNumber('-12.4')).toEqual(-12.4);
+        expect(_.parseNumber(-12.4)).toEqual(-12.4);
         expect(_.parseNumber(123.412)).toEqual(123.412);
         expect(_.parseNumber('123.412')).toEqual(123.412);
         expect(_.parseNumber('123,412')).toEqual(null);
+        expect(_.parseNumber('-123,412')).toEqual(null);
         expect(_.parseNumber('1a23,412')).toEqual(null);
         expect(_.parseNumber('1a23')).toEqual(null);
         expect(_.parseNumber('')).toEqual(null);
+        expect(_.parseNumber('-')).toEqual(null);
         expect(_.parseNumber('awdaw')).toEqual(null);
+        expect(_.parseNumber('-awdaw')).toEqual(null);
         expect(_.parseNumber(true)).toEqual(null);
         expect(_.parseNumber(NaN)).toEqual(null);
-
     });
 });

--- a/src/understreck.js
+++ b/src/understreck.js
@@ -97,9 +97,9 @@ functions.isUndefined = lodash.isUndefined;
 
 functions.parseNumber = function (value, radix) {
     if (functions.isString(value)) {
-        if (/^((\d+\.\d*)|(\d*\.\d+))$/.test(value)) {
+        if (/^-?((\d+\.\d*)|(\d*\.\d+))$/.test(value)) {
             return parseFloat(value);
-        } else if (/^\d+$/.test(value)) {
+        } else if (/^-?\d+$/.test(value)) {
             return parseInt(value, radix || 10);
         } else {
             return null;


### PR DESCRIPTION
ParseNumber fn returned null for negative string values. 
Updated regexp and tests to handle this case. 